### PR TITLE
When expiry timestamp is empty, we try to assign a value to it, but it is a const

### DIFF
--- a/server/src/routes/api/v2/admin/tokens.js
+++ b/server/src/routes/api/v2/admin/tokens.js
@@ -40,7 +40,9 @@ router.post('/create', auth.required, async (req, res) => {
   if (!isCommunityAdmin) {
     return res.status(400).send({ error: 'The user is not a community admin' })
   }
-  const { name, symbol, initialSupply, uri, expiryTimestamp, spendabilityIds, correlationId } = req.body
+  const { name, symbol, initialSupply, uri, spendabilityIds, correlationId } = req.body
+  var { expiryTimestamp } = req.body
+  
   if (!name) {
     return res.status(400).send({ error: 'Missing name' })
   }


### PR DESCRIPTION
## Proposed changes

Hi @leonprou, I just realized this bug when trying out the API after the latest changes. Let's merge it and try again. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
