### PR TITLE
Hardcode gasPrice to 10gwei temporarily

### DIFF
--- a/server/src/utils/web3/send.js
+++ b/server/src/utils/web3/send.js
@@ -164,7 +164,8 @@ const send = async ({ web3, bridgeType, address }, method, options, txContext = 
 
   const from = address
   const gas = await estimateGas()
-  const gasPrice = await getGasPrice(bridgeType, web3)
+  // const gasPrice = await getGasPrice(bridgeType, web3)
+  const gasPrice = '10000000000'
   const account = await Account.findOne({ address })
   for (let i = 0; i < retries; i++) {
     const response = await doSend(i) || {}


### PR DESCRIPTION
## Proposed changes

@leonprou I think this is the easiest way to do it now, once the gasPrice in the network is stabilized to the new value we can switch back to using the `getGasPrice` method that I commented out. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
