### PR TITLE
Restrict wallet addresses returned by appName

### DIFF
--- a/server/src/routes/api/v2/wallets/index.js
+++ b/server/src/routes/api/v2/wallets/index.js
@@ -155,8 +155,9 @@ router.get('/:phoneNumber', auth.required, async (req, res, next) => {
  * @apiSuccess {Object} data Array of Wallet objects
  */
 router.get('/all/:phoneNumber', auth.required, async (req, res, next) => {
+  const { appName } = req.user
   const { phoneNumber } = req.params
-  const userWallets = await UserWallet.find({ phoneNumber }, { contacts: 0 }).sort({ updatedAt: -1 })
+  const userWallets = await UserWallet.find({ phoneNumber, appName }, { contacts: 0 }).sort({ updatedAt: -1 })
 
   return res.json({ data: userWallets })
 })


### PR DESCRIPTION
## Proposed changes

Currently the /all/:phoneNumber endpoint in the wallets API returns all the wallets for a given phone number accross different apps. I believe we should restrict this to the certain app that the request is for (we get the appName from the JWT). 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
